### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A Model Context Protocol (MCP) server providing various random generation utilities, including UUID, numbers, strings, passwords, Gaussian distribution, dice rolling, and card drawing.
 
+<a href="https://glama.ai/mcp/servers/ccd6b0hni8"><img width="380" height="200" src="https://glama.ai/mcp/servers/ccd6b0hni8/badge" alt="Rand MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [MCP Rand](https://glama.ai/mcp/servers/ccd6b0hni8) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ccd6b0hni8"><img width="380" height="200" src="https://glama.ai/mcp/servers/ccd6b0hni8/badge" alt="Rand MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.